### PR TITLE
Duration/EN: Fix composite durations without delimiters

### DIFF
--- a/Duckling/Duration/EN/Corpus.hs
+++ b/Duckling/Duration/EN/Corpus.hs
@@ -88,5 +88,6 @@ allExamples = concat
              ]
   , examples (DurationData 31719604 Second)
              [ "1 year, 2 days, 3 hours and 4 seconds"
+             , "1 year 2 days 3 hours and 4 seconds"
              ]
   ]

--- a/Duckling/Duration/EN/Rules.hs
+++ b/Duckling/Duration/EN/Rules.hs
@@ -175,9 +175,9 @@ ruleDurationPrecision = Rule
         _ -> Nothing
   }
 
-ruleCompositeDuration :: Rule
-ruleCompositeDuration = Rule
-  { name = "composite <duration>"
+ruleCompositeDurationCommasAnd :: Rule
+ruleCompositeDurationCommasAnd = Rule
+  { name = "composite <duration> (with ,/and)"
   , pattern =
     [ Predicate isNatural
     , dimension TimeGrain
@@ -188,6 +188,22 @@ ruleCompositeDuration = Rule
       (Token Numeral NumeralData{TNumeral.value = v}:
        Token TimeGrain g:
        _:
+       Token Duration dd@DurationData{TDuration.grain = dg}:
+       _) | g > dg -> Just . Token Duration $ duration g (floor v) <> dd
+      _ -> Nothing
+  }
+
+ruleCompositeDuration :: Rule
+ruleCompositeDuration = Rule
+  { name = "composite <duration>"
+  , pattern =
+    [ Predicate isNatural
+    , dimension TimeGrain
+    , dimension Duration
+    ]
+  , prod = \case
+      (Token Numeral NumeralData{TNumeral.value = v}:
+       Token TimeGrain g:
        Token Duration dd@DurationData{TDuration.grain = dg}:
        _) | g > dg -> Just . Token Duration $ duration g (floor v) <> dd
       _ -> Nothing
@@ -208,4 +224,5 @@ rules =
   , ruleDurationPrecision
   , ruleNumeralQuotes
   , ruleCompositeDuration
+  , ruleCompositeDurationCommasAnd
   ]


### PR DESCRIPTION
Summary: It would only work with commas/and-separated tokens.

Reviewed By: JonCoens

Differential Revision: D8381351

fbshipit-source-id: eafceeaf5d41bf60aaaf78c3bd6835a768e2b0b6